### PR TITLE
the ingester considers OTHER and NULL to be the same

### DIFF
--- a/src/main/resources/backfill-query.sql
+++ b/src/main/resources/backfill-query.sql
@@ -8,7 +8,10 @@ FROM (SELECT
     -- View-specific factors:
     timestamp_add(timestamp_trunc(event_timestamp, hour), INTERVAL EXTRACT(minute from event_timestamp) - MOD(EXTRACT(minute FROM event_timestamp), 30) minute) as bucket_start,
     range_bucket(attention_time - 1, array[0,1,2,3,4,5,10,15,20,25,30,40,50,60,70,80,90,100,110,120,180,240,300,360,420,480,540,600,900,1200]) AS attention_bucket,
-    referrer_significant_site,
+    (CASE
+         WHEN referrer_significant_site = 'OTHER' THEN NULL
+         ELSE referrer_significant_site
+     END) AS referrer_significant_site,
     (CASE
          WHEN country_code IN ('GB','US','AU','IN','CA','GNM') THEN country_code
          WHEN country_code IN ('AT','BE','BG','HR','CY','CZ','DK','EE','FI','FR','DE','GR','HU','IE','IT','LV','LT','LU','MT','NL','PL','PT','RO','SK','SI','ES','SE') THEN 'EU27'


### PR DESCRIPTION
In order for the CSV files that are output by this tool to be correctly ingested into Elasticsearch by the backfill loader, each CSV row must correspond to a single unique ID when passed through the ID [generation code](https://github.com/guardian/ophan/blob/aa28d1aaee9a7d2956d9355b5e070c716f8ec381/historical-backfill/src/main/scala/ophan/historical/backfill/model/elastic/RollupIDs.scala#L95).

The input to this generation code is the fields generated from one row of the CSV output, and we can see that [the codec](https://github.com/guardian/ophan/blob/c42e45df7161a20dde199a87588ba40ecf8c205f/historical-backfill/src/main/scala/ophan/historical/backfill/model/csv/BucketDumpParser.scala#L20) for that processing treats a missing referrer and a referrer of 'OTHER' as the same thing, i.e. `None`:

```scala
    CellDecoder.from { text =>
      DecodeResult(if (text=="OTHER" || text.isEmpty) None else Some(valuesByUnderscoreName(text)))
    }
```

However, we do not conflate the two possibilities when extracting them from the data lake, which means that these two options will appear as separate rows in the CSV. When they are processed by the backfill they will end up as the same document in elasticsearch, meaning the first that is ingested will be overwritten by the second, and we will end up with less documents in elasticsearch compared to the number of rows.

In order to fix this, this change modifies the SQL query so that it groups these two values together, resulting in just one CSV row, which correctly matches the behaviour of the ingester, and results in the same number of elasticsearch documents as CSV rows.

A CSV file that is generated from this query is included as the test input for the [unit test](https://github.com/guardian/ophan/blob/aa28d1aaee9a7d2956d9355b5e070c716f8ec381/historical-backfill/src/test/scala/ophan/historical/backfill/BackfillIndexingTest.scala#L114) in the backill loader.