### PR TITLE
Reduce size of dumped filenames to fit in AWS State

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ src_managed/
 project/boot/
 .history
 .cache
+.bsp

--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,8 @@ libraryDependencies ++= Seq(
   "com.lihaoyi" %% "upickle" % "1.2.2",
   "com.google.cloud" % "google-cloud-bigquery" % "1.122.2",
   "org.apache.logging.log4j" % "log4j-slf4j-impl" % "2.13.3",
-  "org.slf4j" % "slf4j-api" % "1.7.30"
+  "org.slf4j" % "slf4j-api" % "1.7.30",
+  "org.scalatest" %% "scalatest" % "3.2.2" % Test
 )
 
 enablePlugins(RiffRaffArtifact)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.13
+sbt.version=1.4.7

--- a/src/main/scala/com/gu/ophan/backfill/ExtractData.scala
+++ b/src/main/scala/com/gu/ophan/backfill/ExtractData.scala
@@ -1,8 +1,7 @@
 package com.gu.ophan.backfill
 
-import java.time.Instant
+import java.time.{ Instant, LocalDate, ZoneId }
 import java.time.format.DateTimeFormatter
-import java.time.ZoneId
 
 /**
  * Step 3: Extract data from temporary table created during job
@@ -10,11 +9,13 @@ import java.time.ZoneId
 
 object ExtractDataStep extends SimpleHandler[JobConfig] {
 
+  val FileNameFormat = "backfill.*.csv"
+
   def datestamp(cfg: JobConfig) =
     s"${cfg.startDateInc}--${cfg.endDateExc}"
 
   def destinationURI(cfg: JobConfig)(implicit env: Env) =
-    s"gs://gu-ophan-backfill-${env.stage.toLowerCase}/${cfg.executionId}/backfill.${datestamp(cfg)}.*.csv"
+    s"gs://gu-ophan-backfill-${env.stage.toLowerCase}/${cfg.executionId}_${datestamp(cfg)}/$FileNameFormat"
 
   def process(cfg: JobConfig)(implicit env: Env): JobConfig = {
     val bq = new BigQuery

--- a/src/test/scala/com/gu/ophan/backfill/ExtractDataStepTest.scala
+++ b/src/test/scala/com/gu/ophan/backfill/ExtractDataStepTest.scala
@@ -1,0 +1,32 @@
+package com.gu.ophan.backfill
+
+import org.scalatest.flatspec._
+import org.scalatest.matchers._
+
+class ExtractDataStepTest extends AnyFlatSpec with should.Matchers {
+
+  val MaxBytesAvailableForSingleFilenameLine: Int = {
+    val BytesAvailableForAllFilenameLinesInState = {
+      val StepFunctionMaxStateSizeInBytes = 262144 // https://docs.aws.amazon.com/step-functions/latest/dg/limits.html#service-limits-task-executions
+      val ExtraOneOffBoilerplate = 100 // all the stuff that is *not* the filename lines in the state
+
+      StepFunctionMaxStateSizeInBytes - ExtraOneOffBoilerplate
+    }
+    val NumFilesInLargestBackfill = 2 * 365 * 9
+
+    BytesAvailableForAllFilenameLinesInState / NumFilesInLargestBackfill
+  }
+
+  val MaxSizeOfWildcardFormattedFileName: Int = {
+    val WildcardFileNumberLength = 12 // eg '000000000001' https://cloud.google.com/bigquery/docs/exporting-data#exporting_data_into_one_or_more_files
+    val ExtraBoilerplateCharactersPerFileName = """    "",""".length // eg __    "backfill.xxxx.csv",__ after JSON formatting
+
+    MaxBytesAvailableForSingleFilenameLine - (ExtraBoilerplateCharactersPerFileName + (WildcardFileNumberLength - 1))
+  }
+
+  "Dumped filenames" should "be small enough for 2-years-worth of filenames to fit in AWS Step Functions state" in {
+    MaxSizeOfWildcardFormattedFileName shouldBe 21 // yes, that is what the big sum ends up at
+
+    ExtractDataStep.FileNameFormat.length should be <= MaxSizeOfWildcardFormattedFileName
+  }
+}


### PR DESCRIPTION
As noted in https://github.com/guardian/ophan/pull/3990/commits/dd6fc693abc4cf7322ae460d5f1b1c2706a4b8d4, we need to be careful that filenames don't end up taking up too much space in the AWS Step Function State - [the limit is 256KB](https://aws.amazon.com/blogs/compute/introducing-larger-state-payloads-for-aws-step-functions/)!

I've moved the space-hogging start-and-end-dates from the filename to the parent directory to make the leaf filename itself smaller. The leaf filename goes from:

```
backfill.2020-04-11--2020-04-12.*.csv (goes to backfill.2020-04-11--2020-04-12.000000000000.csv when expanded)
```

to 

```
backfill.*.csv (goes to backfill.000000000000.csv when expanded)
```

The test added with this PR does a bunch of arithmetic to establish that the wildcard-formatted form of the filename must be at most 21 bytes in length. And yes, I'm assuming everything is UTF-8 encoded and all the characters we're using are a single-byte!