### PR TITLE
Use short but also unique filename per sub-job

### DIFF
--- a/src/main/scala/com/gu/ophan/backfill/ExtractData.scala
+++ b/src/main/scala/com/gu/ophan/backfill/ExtractData.scala
@@ -9,13 +9,13 @@ import java.time.format.DateTimeFormatter
 
 object ExtractDataStep extends SimpleHandler[JobConfig] {
 
-  val FileNameFormat = "backfill.*.csv"
+  def fileNameFormat(startDateInc: LocalDate, endDateExc: LocalDate) = s"${startDateInc}_${endDateExc.toEpochDay - startDateInc.toEpochDay}.*.csv"
 
   def datestamp(cfg: JobConfig) =
     s"${cfg.startDateInc}--${cfg.endDateExc}"
 
   def destinationURI(cfg: JobConfig)(implicit env: Env) =
-    s"gs://gu-ophan-backfill-${env.stage.toLowerCase}/${cfg.executionId}_${datestamp(cfg)}/$FileNameFormat"
+    s"gs://gu-ophan-backfill-${env.stage.toLowerCase}/${cfg.executionId}/${fileNameFormat(cfg.startDateInc, cfg.endDateExc)}"
 
   def process(cfg: JobConfig)(implicit env: Env): JobConfig = {
     val bq = new BigQuery

--- a/src/test/scala/com/gu/ophan/backfill/ExtractDataStepTest.scala
+++ b/src/test/scala/com/gu/ophan/backfill/ExtractDataStepTest.scala
@@ -3,6 +3,8 @@ package com.gu.ophan.backfill
 import org.scalatest.flatspec._
 import org.scalatest.matchers._
 
+import java.time.LocalDate
+
 class ExtractDataStepTest extends AnyFlatSpec with should.Matchers {
 
   val MaxBytesAvailableForSingleFilenameLine: Int = {
@@ -26,7 +28,7 @@ class ExtractDataStepTest extends AnyFlatSpec with should.Matchers {
 
   "Dumped filenames" should "be small enough for 2-years-worth of filenames to fit in AWS Step Functions state" in {
     MaxSizeOfWildcardFormattedFileName shouldBe 21 // yes, that is what the big sum ends up at
-
-    ExtractDataStep.FileNameFormat.length should be <= MaxSizeOfWildcardFormattedFileName
+    val now = LocalDate.now()
+    ExtractDataStep.fileNameFormat(now.minusDays(1), now).length should be <= MaxSizeOfWildcardFormattedFileName
   }
 }


### PR DESCRIPTION
After we got https://github.com/guardian/ophan-backfill-step-function/pull/2
in, it looked fine for 1 days worth of data, but when we ran it on a
whole month we soon realised we had a problem:

```
gsutil ls gs://gu-ophan-backfill-prod/
gs://gu-ophan-backfill-prod/11AprilWithShorterFilenames_2020-04-11--2020-04-12/
gs://gu-ophan-backfill-prod/9thMayTo9thJune2020_2020-05-09--2020-05-10/
gs://gu-ophan-backfill-prod/9thMayTo9thJune2020_2020-05-10--2020-05-11/
gs://gu-ophan-backfill-prod/9thMayTo9thJune2020_2020-05-11--2020-05-12/
gs://gu-ophan-backfill-prod/9thMayTo9thJune2020_2020-05-12--2020-05-13/
gs://gu-ophan-backfill-prod/9thMayTo9thJune2020_2020-05-13--2020-05-14/
gs://gu-ophan-backfill-prod/9thMayTo9thJune2020_2020-05-14--2020-05-15/
gs://gu-ophan-backfill-prod/9thMayTo9thJune2020_2020-05-15--2020-05-16/
gs://gu-ophan-backfill-prod/9thMayTo9thJune2020_2020-05-16--2020-05-17/
gs://gu-ophan-backfill-prod/9thMayTo9thJune2020_2020-05-17--2020-05-18/
gs://gu-ophan-backfill-prod/9thMayTo9thJune2020_2020-05-18--2020-05-19/
gs://gu-ophan-backfill-prod/9thMayTo9thJune2020_2020-05-19--2020-05-20/
gs://gu-ophan-backfill-prod/9thMayTo9thJune2020_2020-05-20--2020-05-21/
gs://gu-ophan-backfill-prod/9thMayTo9thJune2020_2020-05-21--2020-05-22/
gs://gu-ophan-backfill-prod/9thMayTo9thJune2020_2020-05-22--2020-05-23/
gs://gu-ophan-backfill-prod/9thMayTo9thJune2020_2020-05-23--2020-05-24/
gs://gu-ophan-backfill-prod/9thMayTo9thJune2020_2020-05-24--2020-05-25/
```

...instead of placing everything into a single parent folder, we were
seeing one per day - which makes sense, given the code, but is no good-
we want a single parent folder, with short filenames inside it!

Also, slightly more subtly, we want all the different BigQuery 'extract'
sub-jobs kicked off by the `Partition` step to have their own 'namespace'
within that parent folder - which was why we'd put the dates in the
leaf filename in the first place!

There are a couple of possible fixes, but the quickest one seemed to be
putting the date back into the leaf filename - but, in order to get the
filename short enough, only using the 'start' date - which still
achieves uniqueness. As a bonus, because we had enough characters of
space left in the filename, we put in the length in days of the period
covered by the job (which should always be 1, unless we change something)
so that you can always work out the 'end' date if you really want to.
