### PR TITLE
Create manifest file for extracted backfill data

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,8 @@ scalacOptions ++= Seq(
   "-deprecation",
   "-encoding", "UTF-8",
   "-target:jvm-1.8",
-  "-Ywarn-dead-code"
+  "-Ywarn-dead-code",
+  "-Wunused:imports"
 )
 
 libraryDependencies ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -24,6 +24,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-ssm" % "1.11.883",
   "com.lihaoyi" %% "upickle" % "1.2.2",
   "com.google.cloud" % "google-cloud-bigquery" % "1.122.2",
+  "com.google.cloud" % "google-cloud-storage" % "1.113.14",
   "org.apache.logging.log4j" % "log4j-slf4j-impl" % "2.13.3",
   "org.slf4j" % "slf4j-api" % "1.7.30",
   "org.scalatest" %% "scalatest" % "3.2.2" % Test

--- a/cloudformation/src/main/scala/lambdas.scala
+++ b/cloudformation/src/main/scala/lambdas.scala
@@ -66,4 +66,8 @@ class BackfillLambdas(
     description = "split the job timespan into smaller jobs to make the data easier to find in GCS",
     handler = "com.gu.ophan.backfill.PartitionStep::handleRequest")
 
+  val stepCreateManifestFile = stepLambda(name = "ManifestFileLambda",
+    description = "create a manifest file which describes how many documents should be created for each date",
+    handler = "com.gu.ophan.backfill.ManifestFileStep::handleRequest")
+
 }

--- a/cloudformation/src/main/scala/states.scala
+++ b/cloudformation/src/main/scala/states.scala
@@ -116,9 +116,13 @@ class BackfillStates(scope: Stack, lambdas: BackfillLambdas) {
       .build()
       .iterator(queryBigQuery)
 
+  lazy val createManifestFileTask =
+    LambdaTask("CreateManifestFile", lambdas.stepCreateManifestFile)
+
   lazy val initialSteps =
     Chain.start(addExecutionId)
       .next(partitionTask)
       .next(mapOverPartitionTask)
+      .next(createManifestFileTask)
 
 }

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -14,6 +14,7 @@ deployments:
         - ophan-backfill-QueryJobStateLambda-
         - ophan-backfill-ExtractDataLambda-
         - ophan-backfill-AwaitExtractJobLambda-
+        - ophan-backfill-ManifestFileLambda-
   cloudformation:
     type: cloud-formation
     dependencies: [ophan-backfill]

--- a/src/main/scala/com/gu/ophan/backfill/ExtractData.scala
+++ b/src/main/scala/com/gu/ophan/backfill/ExtractData.scala
@@ -1,7 +1,6 @@
 package com.gu.ophan.backfill
 
-import java.time.{ Instant, LocalDate, ZoneId }
-import java.time.format.DateTimeFormatter
+import java.time.LocalDate
 
 /**
  * Step 3: Extract data from temporary table created during job
@@ -14,11 +13,10 @@ object ExtractDataStep extends SimpleHandler[JobConfig] {
   def datestamp(cfg: JobConfig) =
     s"${cfg.startDateInc}--${cfg.endDateExc}"
 
-  def pathPrefix(cfg: JobConfig)(implicit env: Env) =
-    s"gs://gu-ophan-backfill-${env.stage.toLowerCase}/${cfg.executionId}"
+  def pathPrefix(cfg: JobConfig)(implicit env: Env) = cfg.executionId
 
   def destinationURI(cfg: JobConfig)(implicit env: Env) =
-    s"${pathPrefix(cfg)}/${fileNameFormat(cfg.startDateInc, cfg.endDateExc)}"
+    s"gs://gu-ophan-backfill-${env.stage.toLowerCase}/${pathPrefix(cfg)}/${fileNameFormat(cfg.startDateInc, cfg.endDateExc)}"
 
   def process(cfg: JobConfig)(implicit env: Env): JobConfig = {
     val bq = new BigQuery

--- a/src/main/scala/com/gu/ophan/backfill/ExtractData.scala
+++ b/src/main/scala/com/gu/ophan/backfill/ExtractData.scala
@@ -14,8 +14,11 @@ object ExtractDataStep extends SimpleHandler[JobConfig] {
   def datestamp(cfg: JobConfig) =
     s"${cfg.startDateInc}--${cfg.endDateExc}"
 
+  def pathPrefix(cfg: JobConfig)(implicit env: Env) =
+    s"gs://gu-ophan-backfill-${env.stage.toLowerCase}/${cfg.executionId}"
+
   def destinationURI(cfg: JobConfig)(implicit env: Env) =
-    s"gs://gu-ophan-backfill-${env.stage.toLowerCase}/${cfg.executionId}/${fileNameFormat(cfg.startDateInc, cfg.endDateExc)}"
+    s"${pathPrefix(cfg)}/${fileNameFormat(cfg.startDateInc, cfg.endDateExc)}"
 
   def process(cfg: JobConfig)(implicit env: Env): JobConfig = {
     val bq = new BigQuery

--- a/src/main/scala/com/gu/ophan/backfill/ExtractData.scala
+++ b/src/main/scala/com/gu/ophan/backfill/ExtractData.scala
@@ -15,8 +15,10 @@ object ExtractDataStep extends SimpleHandler[JobConfig] {
 
   def pathPrefix(cfg: JobConfig)(implicit env: Env) = cfg.executionId
 
+  def bucketName(implicit env: Env) = s"gu-ophan-backfill-${env.stage.toLowerCase}"
+
   def destinationURI(cfg: JobConfig)(implicit env: Env) =
-    s"gs://gu-ophan-backfill-${env.stage.toLowerCase}/${pathPrefix(cfg)}/${fileNameFormat(cfg.startDateInc, cfg.endDateExc)}"
+    s"gs://${bucketName}/${pathPrefix(cfg)}/${fileNameFormat(cfg.startDateInc, cfg.endDateExc)}"
 
   def process(cfg: JobConfig)(implicit env: Env): JobConfig = {
     val bq = new BigQuery

--- a/src/main/scala/com/gu/ophan/backfill/ExtractData.scala
+++ b/src/main/scala/com/gu/ophan/backfill/ExtractData.scala
@@ -31,6 +31,7 @@ object ExtractDataStep extends SimpleHandler[JobConfig] {
     cfg.copy(
       destinationUri = Some(destUri),
       state = JobState.RUNNING,
-      bqJobId = Some(job.getJobId().getJob()))
+      bqJobId = Some(job.getJobId().getJob()),
+      documentCount = Some(table.getNumRows().longValue()))
   }
 }

--- a/src/main/scala/com/gu/ophan/backfill/JobConfig.scala
+++ b/src/main/scala/com/gu/ophan/backfill/JobConfig.scala
@@ -20,7 +20,8 @@ case class JobConfig(
   dataTable: Option[(String, String)] = None,
   destinationUri: Option[String] = None,
   async: Boolean = true,
-  errorMsg: Option[String] = None) {
+  errorMsg: Option[String] = None,
+  documentCount: Option[Long] = None) {
 
   val queryTimeDeclarations: String = s"""
     |DECLARE startTimeInclusive TIMESTAMP DEFAULT TIMESTAMP("${startDateInc.atStartOfDay(UTC).toInstant}");

--- a/src/main/scala/com/gu/ophan/backfill/JobConfig.scala
+++ b/src/main/scala/com/gu/ophan/backfill/JobConfig.scala
@@ -34,14 +34,10 @@ case class JobConfig(
 }
 
 object JobConfig {
-  // sometimes you just have to admire scala ... *sometimes* ...
-  implicit val localDateReader: default.ReadWriter[LocalDate] =
-    upickle.default.readwriter[String].bimap[LocalDate](_.toString, LocalDate.parse)
+  import JsonHelpers._
 
-  implicit val instantReader: default.ReadWriter[Instant] =
-    upickle.default.readwriter[String].bimap[Instant](_.toString, Instant.parse)
-
-  implicit val jobState = upickle.default.readwriter[String].bimap[JobState.Value](_.toString, JobState.withName)
+  implicit val jobState = upickle.default.readwriter[String]
+    .bimap[JobState.Value](_.toString, JobState.withName)
 
   implicit val readWriter = upickle.default.macroRW[JobConfig]
 

--- a/src/main/scala/com/gu/ophan/backfill/JsonHandler.scala
+++ b/src/main/scala/com/gu/ophan/backfill/JsonHandler.scala
@@ -6,6 +6,8 @@ import com.amazonaws.services.lambda.runtime.{ Context, RequestStreamHandler }
 import java.io.InputStream
 import java.io.OutputStream
 import upickle.default.{ Reader, Writer, ReadWriter }
+import java.time.LocalDate
+import java.time.Instant
 
 /**
  * A trait that handles some of the housekeeping of deserialising
@@ -48,3 +50,12 @@ abstract class JsonHandler[Input: Reader, Output: Writer] extends RequestStreamH
 
 // same input and output type
 abstract class SimpleHandler[T: ReadWriter] extends JsonHandler[T, T]
+
+object JsonHelpers {
+  // sometimes you just have to admire scala ... *sometimes* ...
+  implicit val localDateReader: upickle.default.ReadWriter[LocalDate] =
+    upickle.default.readwriter[String].bimap[LocalDate](_.toString, LocalDate.parse)
+
+  implicit val instantReader: upickle.default.ReadWriter[Instant] =
+    upickle.default.readwriter[String].bimap[Instant](_.toString, Instant.parse)
+}

--- a/src/main/scala/com/gu/ophan/backfill/ManifestFileStep.scala
+++ b/src/main/scala/com/gu/ophan/backfill/ManifestFileStep.scala
@@ -1,10 +1,56 @@
 package com.gu.ophan.backfill
 
+import java.io.{BufferedWriter, FileWriter}
+import java.time.LocalDate
+
 object ManifestFileStep extends JsonHandler[Seq[JobConfig], String] {
 
   override def process(input: Seq[JobConfig])(implicit env: Env): String = {
     logger.info("creating manifest file")
+    val manifestLines = input.map { jobConfig =>
+      ManifestFileLine(jobConfig.startDateInc, jobConfig.documentCount)
+    }
+
+    UploadObject.uploadObject(manifest = manifestLines)
     "complete"
   }
 
+  import com.google.cloud.storage.BlobId
+  import com.google.cloud.storage.BlobInfo
+  import com.google.cloud.storage.StorageOptions
+  import java.io.IOException
+  import java.nio.file.Files
+  import java.nio.file.Paths
+
+  //https://cloud.google.com/storage/docs/uploading-objects#storage-upload-object-code-sample
+  object UploadObject {
+    @throws[IOException]
+    def uploadObject(
+      projectId: String = "datatech-platform-prod",
+      bucketName: String = "gu-ophan-backfill-prod/debug-1st-feb", //todo
+      objectName: String = "manifest.json",
+      manifest: Seq[ManifestFileLine]): Unit = { // The ID of your GCP project
+      // String projectId = "your-project-id";
+      // The ID of your GCS bucket
+      // String bucketName = "your-unique-bucket-name";
+      // The ID of your GCS object
+      // String objectName = "your-object-name";
+      // The path to your file to upload
+      // String filePath = "path/to/your/file"
+      val storage = StorageOptions.newBuilder.setProjectId(projectId).build.getService
+      val blobId = BlobId.of(bucketName, objectName)
+      val blobInfo = BlobInfo.newBuilder(blobId).build
+
+      val w: BufferedWriter = new BufferedWriter(new FileWriter(objectName))
+      val manifestAsJson = upickle.default.write[Seq[ManifestFileLine]](manifest)
+      w.write(manifestAsJson)
+      w.close()
+
+      storage.create(blobInfo, Files.readAllBytes(Paths.get(objectName)))
+      System.out.println("File " + " uploaded to bucket " + bucketName + " as " + objectName)
+    }
+  }
+
 }
+
+case class ManifestFileLine(date: LocalDate, count: Option[Long])

--- a/src/main/scala/com/gu/ophan/backfill/ManifestFileStep.scala
+++ b/src/main/scala/com/gu/ophan/backfill/ManifestFileStep.scala
@@ -1,0 +1,10 @@
+package com.gu.ophan.backfill
+
+object ManifestFileStep extends JsonHandler[Seq[JobConfig], String] {
+
+  override def process(input: Seq[JobConfig])(implicit env: Env): String = {
+    logger.info("creating manifest file")
+    "complete"
+  }
+
+}

--- a/src/main/scala/com/gu/ophan/backfill/ManifestFileStep.scala
+++ b/src/main/scala/com/gu/ophan/backfill/ManifestFileStep.scala
@@ -19,15 +19,18 @@ object ManifestFileStep extends JsonHandler[Seq[JobConfig], String] {
         ManifestFileLine(jobConfig.startDateInc, jobConfig.documentCount.get)
       }
 
-      uploadObject(prefix = prefix, manifest = manifestLines)
+      uploadObject(
+        bucketName = ExtractDataStep.bucketName,
+        prefix = prefix,
+        manifest = manifestLines)
     }).getOrElse("<<EMPTY>>")
   }
 
   def uploadObject(
     prefix: String,
+    bucketName: String,
     manifest: Seq[ManifestFileLine],
     projectId: String = "datatech-platform-prod",
-    bucketName: String = "gu-ophan-backfill-prod",
     objectName: String = "manifest.json")(implicit env: Env): String = {
 
     val storage = StorageOptions.newBuilder

--- a/src/main/scala/com/gu/ophan/backfill/ManifestFileStep.scala
+++ b/src/main/scala/com/gu/ophan/backfill/ManifestFileStep.scala
@@ -16,7 +16,7 @@ object ManifestFileStep extends JsonHandler[Seq[JobConfig], String] {
       val prefix = ExtractDataStep.pathPrefix(cfg)
 
       val manifestLines = input.map { jobConfig =>
-        ManifestFileLine(jobConfig.startDateInc, jobConfig.documentCount)
+        ManifestFileLine(jobConfig.startDateInc, jobConfig.documentCount.get)
       }
 
       uploadObject(prefix = prefix, manifest = manifestLines)
@@ -51,7 +51,7 @@ object ManifestFileStep extends JsonHandler[Seq[JobConfig], String] {
   }
 }
 
-case class ManifestFileLine(date: LocalDate, count: Option[Long])
+case class ManifestFileLine(date: LocalDate, count: Long)
 
 object ManifestFileLine {
   import JsonHelpers._

--- a/src/main/scala/com/gu/ophan/backfill/TestIt.scala
+++ b/src/main/scala/com/gu/ophan/backfill/TestIt.scala
@@ -1,9 +1,5 @@
 package com.gu.ophan.backfill
 
-import java.time.Instant
-import java.io.ByteArrayInputStream
-import java.time.temporal.ChronoUnit
-
 object TestIt {
   val example = """
 {
@@ -22,10 +18,11 @@ object TestIt {
       InitBackfillStep :: AwaitQueryJobStep :: ExtractDataStep ::
         AwaitExtractJobStep :: Nil
 
-    steps.foldLeft(cfg) { (cfg, step) =>
+    val res = steps.foldLeft(cfg) { (cfg, step) =>
       val res = step.process(cfg)
       println(res)
       res
     }
+    println(ManifestFileStep.process(res :: Nil))
   }
 }


### PR DESCRIPTION
(Most of this code was written by @lmath , I just tweaked it a bit.)

This change creates a manifest file as the final step of the extraction process. This file consists of a json array which lists the days involved in the extraction, and their corresponding number of CSV rows. The aim is to then use this afterwards to validate indexed data, by confirming that the actual number of documents matches the number of rows in the CSV files.

We decided to do it this way because it takes a long time to count the number of rows after the fact (as you have to download all of the data).

The next step is to update the [validation script](https://gist.github.com/paulmr/14297f1f90c4855a5e0b2985edae8b15) script to use this manifest file instead of downloading the data to count the rows.

An example of a manifest looks like this:

```json
[{"date":"2020-05-09","count":11500250},{"date":"2020-05-10","count":12209227}]
```

Possible further evolutions of this code might create an object keyed off the date instead of an array, but I think at some point we need to get this done so we can proceed with the (second!) backfill.

The run that this was taken from is [here](https://eu-west-1.console.aws.amazon.com/states/home?region=eu-west-1#/executions/details/arn:aws:states:eu-west-1:021353022223:execution:OphanBackfillExtractorAF53033F-FG1hRg9d46yf:e3788ac6-9170-ac16-ff7e-28d138d7db73).