### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Step function for performan the Ophan Backfill
+# Ophan backfill: Data lake extractor
+
+-----
 
 ## What is this?
 
@@ -7,21 +9,21 @@ existing pageview data at launch time, we would like to extract that
 data from the data lake and insert it into the rollup index.
 
 This repo contains a step function which does the first part of that:
-it uses BigQuery to talk to the the data lake, using an SQL query
+it uses BigQuery to talk to the data lake, using an SQL query
 (contained in the `src/main/resources` directory of this repo). This
 query, as well as extracting the actual data, groups that data on
-fields that match the historical data index, effecitvely replicating
+fields that match the historical data index, effectively replicating
 the 'rollup'.
 
 This data is then output into a CSV file which can be consumed by the
 ingester portion of the backfill process.
 
-## Doing a backfill
+## Extracting pageviews from the data lake
 
-In order to actually perform a backfill, the only thing you need to do
-is initiate an execution of the step function from the [Step
+In order to actually perform a backfill, the first thing you need to do
+is initiate an execution of the **OphanBackfillExtractorAF53033F-FG1hRg9d46yf** step function from the [Step
 Function's
-page](https://eu-west-1.console.aws.amazon.com/states/home?region=eu-west-1#/statemachines/view/arn:aws:states:eu-west-1:021353022223:stateMachine:Ophan-Backfill-Extractor)
+page](https://eu-west-1.console.aws.amazon.com/states/home?region=eu-west-1#/statemachines)
 in the AWS console.
 
 The input that it is expecting is a JSON object defining the start
@@ -35,15 +37,18 @@ be extracted:
 }
 ```
 
-This will then trigger the backfill, to extract the data from the data
-lake, and it will export the results as CSV files in the bucket
-`gs://gu-ophan-backfill-prod` (the final output of the step function
+This will extract pageviews from the data
+lake, exporting the results as CSV files in the bucket
+`gs://gu-ophan-backfill-prod`. The final output of the step function
 will contain the URL that was used to output the data, in the field
-`destinationUri`).
+`destinationUri`.
+
+For the step function itself, follow the naming convention `backfill-with-manifest-21jun2021-04jul2021`
+to keep things clear.
 
 ## Authentication
 
 In order to access BigQuery, the step function needs to be able to
 read the keys for the BigQuery service account from AWS's secure
-paramter store, so make sure these keys exist and are up to date (see
+parameter store, so make sure these keys exist and are up to date (see
 `auth.scala`).

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ the 'rollup'.
 This data is then output into a CSV file which can be consumed by the
 ingester portion of the backfill process.
 
+**For more information read the full [Ophan backfill guide](https://github.com/guardian/ophan/blob/main/docs/developing-ophan/how-to-do-a-backfill.md).**
+
 ## Extracting pageviews from the data lake
 
 In order to actually perform a backfill, the first thing you need to do


### PR DESCRIPTION
Tidy up typos, fix broken links, and improve clarity following a recent backfill.

This should be amended once https://github.com/guardian/ophan/pull/4213 has been merged, with the readme here linking to full Ophan documentation.
