### PR TITLE
Filter out dangerously long paths

### DIFF
--- a/src/main/resources/backfill-query.sql
+++ b/src/main/resources/backfill-query.sql
@@ -49,6 +49,7 @@ FROM (SELECT
     FROM datalake.pageview
     WHERE
     received_date between date(startTimeInclusive) and DATE_ADD(date(endTimeExclusive), INTERVAL 7 DAY) -- events can be received much later than they occur. Restricting received_date is valuable because it constrains the amount of data loaded by BigQuery
+    and length(path) < 350 -- we don't believe any legitimate paths are longer than about 250 characters
     GROUP BY 1,2,3,4,5,6,7,8,9,10,11
 ) AS results
 where


### PR DESCRIPTION
We sometimes receive spurious pageviews for dangerously long paths, e.g.

```
/xdownload/html/~%257B%2522query%2522%253A%257B%2522name%2522%253A%2522intel%2522%252C%2522text%2522%253A%2522Al-Qaida%2522%257D%252C%2522cacheId%2522%253A%2522640BA31BFA344E348C9CDCF9BCF5A861%2522%252C%2522browserUr/l%2522%253A%2522http%253A%255C%252F%255C%252Flocalhost%253A83%255C%252Fapp-debug%255C%252Fintel%255C%252F%2522%252C%2522app%2522%253A%2522intel%2522%252C%2522id%2522%253A%2522%255C%252FWeb%255C%252FT/witter%255C%252F%257C1188925629565198337%257CL%25230_1188925629565198337%2522%257D~/file.htm
```

...which we don't want to extract from the Data Lake for backfilling, because querying CAPI for too many long paths at a time results in a `com.gu.contentapi.client.model.ContentApiError: Request-URI Too Long`

The longest genuine paths we've seen are around 250 characters long:
https://github.com/guardian/ophan/blob/a3146af58c53ab3085f62bbabfd8b5d17dad18dd/shared-lib/src/main/scala/ophan/capi/contentcache/BulkCapiRequestor.scala#L30