### PR TITLE
Prevent null pointer exception during awaitJob

### DIFF
--- a/src/main/scala/com/gu/ophan/backfill/AwaitQueryJobStep.scala
+++ b/src/main/scala/com/gu/ophan/backfill/AwaitQueryJobStep.scala
@@ -10,8 +10,8 @@ import com.google.cloud.bigquery.Job
 
 object AwaitQueryJobStep extends SimpleHandler[JobConfig] with AwaitJob {
   override def onComplete(cfg: JobConfig, job: Job): JobConfig = {
-    val destTable = job.getConfiguration[QueryJobConfiguration]().getDestinationTable()
-    logger.info(s"Destination table: ${destTable}")
-    cfg.copy(dataTable = Some((destTable.getDataset(), destTable.getTable())))
+    val destTable = Option(job.getConfiguration[QueryJobConfiguration]().getDestinationTable)
+    logger.info(s"Destination table: $destTable")
+    cfg.copy(dataTable = destTable.map(dt => (dt.getDataset, dt.getTable)))
   }
 }


### PR DESCRIPTION
During the CheckQueryJobStatus step of the Ophan backfill extractor step function, we encounter a null pointer exception due to the destination table being null here:

https://github.com/guardian/ophan-backfill-step-function/blob/db6f8eba3c755fbd1e7a11064a0cd5b52e620929/src/main/scala/com/gu/ophan/backfill/AwaitQueryJobStep.scala#L13

Wrapping it in an Option should prevent this step from crashing, but we don't yet know whether the crash will just propagate further down the step function.
