### PR TITLE
Updates backfill query to use Day time bucket and Council of Europe country_code

### DIFF
--- a/src/main/resources/backfill-query.sql
+++ b/src/main/resources/backfill-query.sql
@@ -6,7 +6,7 @@ DECLARE endTimeExclusive TIMESTAMP DEFAULT TIMESTAMP("2020-09-28T16:00:00Z");
 SELECT results.*
 FROM (SELECT
     -- View-specific factors:
-    timestamp_add(timestamp_trunc(event_timestamp, hour), INTERVAL EXTRACT(minute from event_timestamp) - MOD(EXTRACT(minute FROM event_timestamp), 30) minute) as bucket_start,
+    timestamp_trunc(event_timestamp, day) as bucket_start,
     range_bucket(attention_time - 1, array[0,1,2,3,4,5,10,15,20,25,30,40,50,60,70,80,90,100,110,120,180,240,300,360,420,480,540,600,900,1200]) AS attention_bucket,
     (CASE
          WHEN referrer_significant_site = 'OTHER' THEN NULL
@@ -14,7 +14,11 @@ FROM (SELECT
      END) AS referrer_significant_site,
     (CASE
          WHEN country_code IN ('GB','US','AU','IN','CA','GNM') THEN country_code
-         WHEN country_code IN ('AT','BE','BG','HR','CY','CZ','DK','EE','FI','FR','DE','GR','HU','IE','IT','LV','LT','LU','MT','NL','PL','PT','RO','SK','SI','ES','SE') THEN 'EU27'
+         WHEN country_code IN ("AL", "AD", "AM", "AT", "AZ", "BE", "BA", "BG", "HR",
+                               "CY", "CZ", "DK", "EE", "FI", "FR", "GE", "DE", "GR",
+                               "HU", "IS", "IE", "IT", "LV", "LI", "LT", "LU", "MT",
+                               "MC", "ME", "NL", "MK", "NO", "PL", "PT", "MD", "RO",
+                               "SM", "RS", "SK", "SI", "ES", "SE", "CH", "TR", "UA") THEN 'COE'
          WHEN country_code IS NOT NULL THEN 'ROW'
       END) AS rollup_country_code,
     (CASE


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR aims to update the backfill process to reflect the latest decisions regarding [historical rollup granularity](https://github.com/orgs/guardian/projects/62/views/4?filterQuery=).

From experimenting in Big Query, we have determined it is possible to reduce the storage requirements of the historical index by ~63%:
<img width="406" alt="image" src="https://user-images.githubusercontent.com/4633246/194338621-c3d3450b-6876-4160-99be-54c193e5c042.png">
– [Google Sheet](https://docs.google.com/spreadsheets/d/1QoMgXtyaawinXCr7_I3MppFCvxxGc0eSA_Tpph20eBo/edit#gid=1850738565)

The main improvement in regards to storage requirements is the reduction of time granularity from 30 minutes to 1 day rollups. 

This change also reflects a change to the [Europe county code](https://github.com/guardian/ophan/pull/4837) made recently in Ophan. 

## How to test

We will want to perform a trail run of this extraction process to confirm it works as intended.

We can deploy this branch to PROD to verify this. 

## How can we measure success?

We are able to create a historical snapshot which reflects the new level of granularity intended for the historical index.

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
